### PR TITLE
fix gallery name parsing because of layout change

### DIFF
--- a/plugins/NHentai Downloader/main.py
+++ b/plugins/NHentai Downloader/main.py
@@ -84,10 +84,12 @@ def download_query(item):
         log.info("parsing gallery info")
         info_div = soup.find("div", id="info")
         if info_div:
-            title_el = soup.find("h1")
+            title_el = soup.find("h1", class_="title")
             if title_el:
-                item.name = str(title_el.string)
-                log.info(f"found name of gallery: {item.name}")
+                title_name = soup.find("span", class_="pretty")
+                if title_name:
+                    item.name = str(title_name.string)
+                    log.info(f"found name of gallery: {item.name}")
         else:
             log.warning("couldn't find gallery info div")
 


### PR DESCRIPTION
Title was always "None" because the page layout changed and they put multiple <span> inside the <h1>